### PR TITLE
Some changes in how tools are saved, and also added reading from bytes

### DIFF
--- a/src/items.zig
+++ b/src/items.zig
@@ -773,7 +773,7 @@ pub const Tool = struct { // MARK: Tool
 		var craftingGridMask: u32 = 0;
 		for(0..craftingGridSize) |i| {
 			if(self.craftingGrid[i] != null) {
-				craftingGridMask |= 1 << i;
+				craftingGridMask |= @as(u32, 1) << @intCast(i);
 			}
 		}
 		writer.writeInt(u32, craftingGridMask);
@@ -793,12 +793,12 @@ pub const Tool = struct { // MARK: Tool
 		var craftingGrid: [craftingGridSize]?BaseItemIndex = @splat(null);
 		while(craftingGridMask != 0) {
 			const i = @ctz(craftingGridMask);
-			craftingGridMask &= ~(1 << i);
+			craftingGridMask &= ~(@as(u32, 1) << @intCast(i));
 			craftingGrid[i] = try BaseItemIndex.readBytes(reader);
 		}
 		const durability = try reader.readInt(u32);
 		const seed = try reader.readInt(u32);
-		const typ = .{.index = try reader.readInt(u16)};
+		const typ: ToolTypeIndex = .{.index = try reader.readInt(u16)};
 		const self = initFromCraftingGrid(craftingGrid, seed, typ);
 		self.durability = durability;
 		return self;

--- a/src/items.zig
+++ b/src/items.zig
@@ -778,14 +778,12 @@ pub const Tool = struct { // MARK: Tool
 		for(0..craftingGridSize) |i| {
 			if(self.craftingGrid[i]) |baseItem| {
 				baseItem.writeBytes(writer);
-			} else {
-				writer.writeInt(u16, 0);
 			}
 		}
 
 		writer.writeInt(u32, self.durability);
 		writer.writeInt(u32, self.seed);
-		writer.writeInt(u32, self.seed);
+		writer.writeInt(u16, self.type.index);
 	}
 };
 


### PR DESCRIPTION
- I used `@ctz` to get the next index that is needed from the crafting inventory mask, and then I zero out that bit so it gets ignored next time.
- I removed the `writer.writeInt(u16, 0);` since the crafting table mask already fills that purpose
- I added `readBytes` and `writeBytes` to ItemStack