### PR TITLE
Jungle tweaks

### DIFF
--- a/assets/cubyz/biomes/jungle.zig.zon
+++ b/assets/cubyz/biomes/jungle.zig.zon
@@ -18,8 +18,8 @@
 
 	.ground_structure = .{
 		"cubyz:lush_grass",
+		"3 to 4 cubyz:mud"
 	},
-	.stoneBlock = "cubyz:soil",
 
 	.structures = .{
 		.{
@@ -60,21 +60,12 @@
 		},
 		.{
 			.id = "cubyz:ground_patch",
-			.block = "cubyz:soil",
-			.chance = 0.04,
-			.width = 4,
-			.variation = 4,
+			.block = "cubyz:mud",
+			.chance = 0.2,
+			.width = 5,
+			.variation = 6,
 			.depth = 2,
-			.smoothness = 0.2,
-		},
-		.{
-			.id = "cubyz:ground_patch",
-			.block = "cubyz:grass",
-			.chance = 0.1,
-			.width = 4,
-			.variation = 4,
-			.depth = 2,
-			.smoothness = 0.2,
+			.smoothness = 0.6,
 		},
 		.{
 			.id = "cubyz:flower_patch",


### PR DESCRIPTION
- replace soil with mud:
Soil has really poor contrast against lush grass and mahogany log, with mud you get a lot more depth in the biome. 
I added some large mud patches, since typically you won't see much grass under the dense canopy of a jungle
- remove regular grass patches
This is kinda subjective, I just don't really like how it looks, especially in the very small patches
- remove soil stoneBlock
This was here before you touched jungles, and it has the problem of preventing ores from appearing near the surface (since soil doesn't spawn ores)

<img width="1229" height="668" alt="image" src="https://github.com/user-attachments/assets/05150f94-1de7-468c-93b6-2e06a1f4ccbc" />
